### PR TITLE
nvmath: Fix SSE detection logic

### DIFF
--- a/src/nvmath/ftoi.h
+++ b/src/nvmath/ftoi.h
@@ -53,7 +53,8 @@ namespace nv
         return (val<0) ? ftoi_ceil_xs(val) : ftoi_floor_xs(val);
     }
 
-#if NV_CPU_X86 || NV_CPU_X86_64
+
+#if NV_USE_SSE
 
     NV_FORCEINLINE int ftoi_round_sse(float f) {
         return _mm_cvt_ss2si(_mm_set_ss(f));
@@ -62,12 +63,6 @@ namespace nv
     NV_FORCEINLINE int ftoi_trunc_sse(float f) {
       return _mm_cvtt_ss2si(_mm_set_ss(f));
     }
-
-#endif
-
-
-
-#if NV_USE_SSE
 
     NV_FORCEINLINE int ftoi_round(float val) {
         return ftoi_round_sse(val);

--- a/src/nvmath/nvmath.h
+++ b/src/nvmath/nvmath.h
@@ -14,12 +14,6 @@
 #include <float.h>  // finite, isnan
 #endif
 
-#if NV_CPU_X86 || NV_CPU_X86_64
-    //#include <intrin.h>
-    #include <xmmintrin.h>
-#endif
-
-
 
 // Function linkage
 #if NVMATH_SHARED
@@ -42,28 +36,31 @@
 #endif
 
 #ifndef NV_USE_SSE
+    // 1=SSE, 2=SSE2
 #   if NV_CPU_X86_64
         // x64 always supports at least SSE2
 #       define NV_USE_SSE 2
 #   elif NV_CC_MSVC && defined(_M_IX86_FP)
         // Also on x86 with the /arch:SSE flag in MSVC.
-#       define NV_USE_SSE _M_IX86_FP       // 1=SSE, 2=SS2
-#   elif defined(__SSE__)
-#       define NV_USE_SSE 1
+#       define NV_USE_SSE _M_IX86_FP
 #   elif defined(__SSE2__)
 #       define NV_USE_SSE 2
+#   elif defined(__SSE__)
+#       define NV_USE_SSE 1
 #   else
         // Otherwise we assume no SSE.
 #       define NV_USE_SSE 0
 #   endif
 #endif
 
+#if NV_USE_SSE
+    #include <xmmintrin.h>
+#endif
 
 // Internally set NV_USE_SIMD when either altivec or sse is available.
 #if NV_USE_ALTIVEC && NV_USE_SSE
 #	error "Cannot enable both altivec and sse!"
 #endif
-
 
 
 #ifndef PI


### PR DESCRIPTION
Some code assumed that `NV_CPU_X86 || NV_CPU_X86_64` is enough to check
for SSE support, but that's wrong. There are plenty of older x86 CPUs
which don't support SSE (see [this Godot Engine issue](https://github.com/godotengine/godot/issues/14709)).

Also fixed the SSE2 detection logic, previously it could not reach the
`#elif __SSE2__` branch since `__SSE__` is defined too when SSE2 is supported.